### PR TITLE
Improve stability of ViewerRTX on Windows

### DIFF
--- a/newton/_src/viewer/viewer_rtx.py
+++ b/newton/_src/viewer/viewer_rtx.py
@@ -122,6 +122,7 @@ class ViewerRTX(ViewerUSD):
         # Pyglet window state
         self._window = None
         self._pyglet_app = None
+        self._pyglet_event_loop_started = False
         self._should_close = False
         self._camera_dirty = True
 
@@ -186,6 +187,21 @@ class ViewerRTX(ViewerUSD):
             vsync=self._vsync_init,
         )
         self._pyglet_app = pyglet.app
+
+        if not self._headless:
+            # Match the GL viewer's synchronous event-loop setup so the Win32
+            # backend is pumping messages before we start dispatching events.
+            from pyglet.window import Window
+
+            Window._enable_event_queue = False
+            self._window.dispatch_pending_events()
+            try:
+                self._pyglet_app.platform_event_loop.start()
+            except RuntimeError:
+                # Pyglet raises if the platform loop is already running.
+                pass
+            else:
+                self._pyglet_event_loop_started = True
 
         # ---- GL texture + shader for zero-copy blit --------------------------
         self._window.switch_to()
@@ -646,6 +662,8 @@ void main() {
                 semantic=Semantic.XFORM_MAT4x4,
                 prim_mode=PrimMode.MUST_EXIST,
             )
+        else:
+            self._transform_binding = None
 
         # Create the presentation window now that all Warp kernels have been
         # compiled.  Doing this earlier causes a deadlock on Windows because
@@ -654,6 +672,14 @@ void main() {
         self._init_window()
 
         self._phase = self._PHASE_RENDER
+
+    def _require_transform_binding(self):
+        if self._transform_binding is None:
+            raise RuntimeError(
+                "ViewerRTX cannot update instanced transforms because the OVRTX "
+                "transform binding was not initialized during the build phase."
+            )
+        return self._transform_binding
 
     # ------------------------------------------------ ViewerUSD overrides
 
@@ -792,6 +818,9 @@ void main() {
                 self._instance_prim_paths[name] = paths
         else:
             if xforms is not None:
+                if len(xforms) == 0:
+                    return
+                self._require_transform_binding()
                 if scales is None:
                     scales = wp.ones(len(xforms), dtype=wp.vec3)
                 self._pending_xforms[name] = (xforms, scales)
@@ -839,12 +868,13 @@ void main() {
             self._camera_dirty = False
 
     def _update_ovrtx_transforms(self):
-        if not self._transform_binding or not self._pending_xforms:
+        if not self._pending_xforms:
             return
+        transform_binding = self._require_transform_binding()
         with wp.ScopedTimer("ViewerRTX::update_transforms", active=PROFILE_ENABLED, use_nvtx=True):
             from ovrtx import Device
 
-            with self._transform_binding.map(device=Device.CUDA) as mapping:
+            with transform_binding.map(device=Device.CUDA) as mapping:
                 matrices = wp.from_dlpack(mapping.tensor, dtype=wp.mat44d)  # (N, 4, 4) float64
 
                 offset = 0
@@ -856,7 +886,9 @@ void main() {
                         wp.launch(write_transforms, dim=n, inputs=[xf, sc, offset, matrices], device=matrices.device)
                     offset += count
 
-                mapping.unmap(stream=matrices.device.stream.cuda_stream)
+                stream = getattr(matrices.device, "stream", None)
+                cuda_stream = getattr(stream, "cuda_stream", None)
+                mapping.unmap(stream=cuda_stream)
 
     @staticmethod
     def _make_point3f_dltensor(points_np):
@@ -893,39 +925,6 @@ void main() {
                     tensors=[dl],
                 )
 
-    @staticmethod
-    def _xform_to_mat44(pos, quat, scale):
-        """Convert (pos, quaternion_xyzw, scale) to 4x4 row-major matrix (float64).
-
-        Matches the USD GfMatrix4d / OVRTX fabric convention where the
-        translation lives in the last row and basis vectors in the first three.
-        """
-        x, y, z, w = float(quat[0]), float(quat[1]), float(quat[2]), float(quat[3])
-        sx, sy, sz = float(scale[0]), float(scale[1]), float(scale[2])
-
-        xx, yy, zz = x * x, y * y, z * z
-        xy, xz, yz = x * y, x * z, y * z
-        wx, wy, wz = w * x, w * y, w * z
-
-        mat = np.empty((4, 4), dtype=np.float64)
-        mat[0, 0] = (1.0 - 2.0 * (yy + zz)) * sx
-        mat[0, 1] = (2.0 * (xy + wz)) * sx
-        mat[0, 2] = (2.0 * (xz - wy)) * sx
-        mat[0, 3] = 0.0
-        mat[1, 0] = (2.0 * (xy - wz)) * sy
-        mat[1, 1] = (1.0 - 2.0 * (xx + zz)) * sy
-        mat[1, 2] = (2.0 * (yz + wx)) * sy
-        mat[1, 3] = 0.0
-        mat[2, 0] = (2.0 * (xz + wy)) * sz
-        mat[2, 1] = (2.0 * (yz - wx)) * sz
-        mat[2, 2] = (1.0 - 2.0 * (xx + yy)) * sz
-        mat[2, 3] = 0.0
-        mat[3, 0] = float(pos[0])
-        mat[3, 1] = float(pos[1])
-        mat[3, 2] = float(pos[2])
-        mat[3, 3] = 1.0
-        return mat
-
     # ------------------------------------------------------- render + display
 
     def _update_fps(self):
@@ -951,16 +950,23 @@ void main() {
                 products = self._render_result.wait() if self._render_result is not None else None
 
             if products is not None:
-                for _pname, product in products.items():
-                    for frame in product.frames:
-                        if "LdrColor" in frame.render_vars:
-                            with wp.ScopedTimer("ViewerRTX::fb_map", active=PROFILE_ENABLED, use_nvtx=True):
-                                with frame.render_vars["LdrColor"].map(device=Device.CPU) as mapping:
-                                    pixels = np.from_dlpack(mapping.tensor)
-                                    with wp.ScopedTimer(
-                                        "ViewerRTX::blit_to_window", active=PROFILE_ENABLED, use_nvtx=True
-                                    ):
-                                        self._blit_to_window(pixels)
+                try:
+                    for _pname, product in products.items():
+                        for frame in product.frames:
+                            if "LdrColor" in frame.render_vars:
+                                with wp.ScopedTimer("ViewerRTX::fb_map", active=PROFILE_ENABLED, use_nvtx=True):
+                                    with frame.render_vars["LdrColor"].map(device=Device.CPU) as mapping:
+                                        pixels = np.from_dlpack(mapping.tensor)
+                                        with wp.ScopedTimer(
+                                            "ViewerRTX::blit_to_window", active=PROFILE_ENABLED, use_nvtx=True
+                                        ):
+                                            self._blit_to_window(pixels)
+                finally:
+                    products.destroy()
+
+            if not self.is_running():
+                self._render_result = None
+                return
 
             # kick off next async rendering frame
             with wp.ScopedTimer("ViewerRTX::rtx_step", active=PROFILE_ENABLED, use_nvtx=True):
@@ -1060,6 +1066,15 @@ void main() {
 
     @override
     def close(self):
+        if self._render_result is not None:
+            try:
+                products = self._render_result.wait(step_timeout_ns=5_000_000_000, fetch_timeout_ns=5_000_000_000)
+                if products is not None:
+                    products.destroy()
+            except Exception:
+                pass
+            self._render_result = None
+
         if self._transform_binding is not None:
             self._transform_binding.unbind()
             self._transform_binding = None
@@ -1069,7 +1084,7 @@ void main() {
             self.ui.shutdown()
 
         if self._window is not None:
-            if not self._headless:
+            if not self._headless and self._pyglet_event_loop_started and self._pyglet_app is not None:
                 try:
                     self._pyglet_app.event_loop.dispatch_event("on_exit")
                     self._pyglet_app.platform_event_loop.stop()
@@ -1077,3 +1092,4 @@ void main() {
                     pass
             self._window.close()
             self._window = None
+            self._pyglet_event_loop_started = False


### PR DESCRIPTION
# ViewerRTX Windows Improvements

## Summary

The goal of these changes is to make `ViewerRTX` start up, render, and shut
down reliably on Windows without giving up the GPU-resident OVRTX transform
binding path that is needed for complex scenes.

## Why These Changes Were Needed

On Windows, the RTX viewer was vulnerable to hangs during initialization and
shutdown. The most important failure modes were:

- the Win32 event loop not being fully initialized before the viewer started
  driving window events
- asynchronous OVRTX render work still being in flight while the viewer was
  shutting down
- transform updates silently doing nothing if the persistent OVRTX transform
  binding was unavailable

These issues are especially problematic for larger scenes because the intended
high-performance path is the persistent transform binding, where instance
transforms stay on the GPU and are updated via a mapped OVRTX buffer.

## Improvements

### 1. More Robust Window/Event-Loop Initialization

The RTX viewer now starts pyglet's platform event loop before it begins
manually dispatching window events.

Why this is necessary:

- Windows relies on the message pump being active at the right time
- starting the platform event loop earlier reduces the chance of Win32 event
  handling stalling during viewer startup
- this aligns the RTX viewer more closely with the already-working GL viewer
  setup

### 2. Keep the Persistent OVRTX Transform Binding Path

The viewer continues to create a persistent OVRTX binding for
`omni:xform` when instanced prim paths are present.

Why this is necessary:

- this is the intended high-performance path
- transform updates remain GPU-resident
- large or complex scenes avoid an unnecessary CPU transform conversion and
  upload path
- it preserves the scalability advantages of mapped CUDA buffers and Warp
  kernel writes

### 3. Fail Fast if the Transform Binding Is Missing

The viewer now treats the transform binding as required when instanced
transforms are being updated.

Why this is necessary:

- if the binding is missing, transform updates cannot work correctly
- silently returning from the update path would hide a broken renderer state
- raising early makes bugs obvious during development and debugging instead of
  producing a scene with frozen or stale transforms

In practice this means:

- `_update_ovrtx_transforms()` only returns early when there are no pending
  instance updates
- if there are pending instance updates, the viewer requires the transform
  binding and raises immediately if it is absent
- `log_instances()` in render phase also validates that the instancer was
  registered during the build phase

### 4. Safer GPU Buffer Unmap Behavior

The transform update path still maps the OVRTX binding on `Device.CUDA`, writes
matrices via Warp, and unmaps using the active CUDA stream.

Why this is necessary:

- it keeps transform writes synchronized with the GPU work that produced them
- it avoids downgrading the transform path to CPU memory
- it preserves zero-copy behavior for the mapped transform buffer

### 5. Clean Up Async Render Results Every Frame

Fetched OVRTX render outputs are now explicitly destroyed after each frame is
consumed.

Why this is necessary:

- OVRTX step results own renderer-side resources
- if fetched outputs are not destroyed, the viewer can leak render-result
  objects
- explicit cleanup reduces shutdown noise and avoids resource accumulation

### 6. Do Not Queue a New Async Render on the Final Frame

The viewer now stops scheduling a new `step_async()` once the viewer is no
longer running.

Why this is necessary:

- otherwise the viewer can enqueue one extra render that will never be
  presented
- that leaves unnecessary in-flight work to clean up during shutdown
- reducing late async work makes shutdown more predictable on Windows

### 7. Drain Outstanding Async Render Work During Shutdown

Before tearing the renderer down, the viewer now waits for any outstanding
render result and destroys the fetched outputs if they exist.

Why this is necessary:

- OVRTX shutdown is more reliable when pending async work has been drained
- it avoids destroying renderer state while step/fetch work is still active
- it makes resource ownership explicit at shutdown time

### 8. Normal Binding Unbind Is Used Again

The current implementation uses normal `self._transform_binding.unbind()`
cleanup again.

Why this is necessary:

- the binding should be released cleanly rather than ignored or bypassed
- once render-result cleanup was fixed, synchronous binding teardown behaved
  correctly again in validation runs
- this keeps the renderer lifecycle coherent and avoids leaving outstanding
  binding handles behind

## Net Effect

Taken together, these changes improve Windows stability while preserving the
GPU-first design of the RTX viewer:

- startup is less likely to stall in the window/event-loop path
- transform updates stay on the persistent GPU binding path
- shutdown is less likely to race against in-flight async OVRTX work
- missing transform-binding state now fails loudly instead of silently

## Validation

The updated path was validated on Windows with a direct `ViewerRTX` run of the
basic shapes example for multiple frames. The viewer initialized, rendered, and
exited successfully using the persistent transform binding path.

This validation was targeted, not a full repository-wide test run.

## Remaining Follow-Up

There are still OVRTX warnings of the form:

- `Unsupported type encountered during VtValue extraction`
- `Attempting to set an invalid data source to array attribute`

These warnings appear to be separate from the transform-binding stability work.
They should be investigated independently if they affect rendering correctness
or performance.
